### PR TITLE
Add support for test fragments

### DIFF
--- a/examples/basic_fragment_module.rb
+++ b/examples/basic_fragment_module.rb
@@ -2,7 +2,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'ruby-jmeter'
 
 test do
-  test_fragment name: 'Fragment - Google' do
+  fragment name: 'Fragment - Google' do
     visit name: 'Home Page', url: 'http://google.com/'
   end
   threads count: 1 do

--- a/examples/basic_fragment_module.rb
+++ b/examples/basic_fragment_module.rb
@@ -1,0 +1,15 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+require 'ruby-jmeter'
+
+test do
+  test_fragment name: 'Fragment - Google' do
+    visit name: 'Home Page', url: 'http://google.com/'
+  end
+  threads count: 1 do
+    module_controller name: 'google', node_path: [
+      'WorkBench', # first entry is always WorkBench
+      'TestPlan', # name of the test, default is TestPlan
+      'Fragment - Google' # name of the fragment.
+    ]
+  end
+end.run(path: '/usr/share/jmeter/bin/', gui: true)

--- a/examples/real_fragment_module_github.rb
+++ b/examples/real_fragment_module_github.rb
@@ -1,0 +1,37 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+require 'ruby-jmeter'
+
+# This example shows how to assemble test scenarios as sequences of reusable steps.
+
+test do
+
+  test_fragment name: 'Fragment: Home Page' do
+    visit name: 'home page', url: 'https://github.com'
+  end
+
+  test_fragment name: 'Fragment: Project Search' do
+    visit name: 'search for project', url: 'https://github.com/search?q=ruby-jmeter&ref=cmdform'
+  end
+
+  test_fragment name: 'Fragment: Project Page' do
+    visit name: 'project page', url: 'https://github.com/flood-io/ruby-jmeter'
+  end
+
+  threads 1, name: 'Search for project' do
+    transaction name: 'Search for project' do
+      think_time 10, 3
+      module_controller name: 'visit home page', node_path: [ 'WorkBench', 'TestPlan', 'Fragment: Home Page' ]
+      module_controller name: 'search for project', node_path: [ 'WorkBench', 'TestPlan', 'Fragment: Project Search' ]
+      module_controller name: 'visit project page', node_path: [ 'WorkBench', 'TestPlan', 'Fragment: Project Page' ]
+    end
+  end
+
+  threads 1, name: 'Go directly to project' do
+    transaction name: 'Direct project page' do
+      think_time 10, 3
+      module_controller name: 'visit project page', node_path: [ 'WorkBench', 'TestPlan', 'Fragment: Project Page' ]
+    end
+
+  end
+end.run(path: '/usr/share/jmeter/bin/', gui: true)
+

--- a/examples/real_fragment_module_github.rb
+++ b/examples/real_fragment_module_github.rb
@@ -5,15 +5,15 @@ require 'ruby-jmeter'
 
 test do
 
-  test_fragment name: 'Fragment: Home Page' do
+  fragment name: 'Fragment: Home Page' do
     visit name: 'home page', url: 'https://github.com'
   end
 
-  test_fragment name: 'Fragment: Project Search' do
+  fragment name: 'Fragment: Project Search' do
     visit name: 'search for project', url: 'https://github.com/search?q=ruby-jmeter&ref=cmdform'
   end
 
-  test_fragment name: 'Fragment: Project Page' do
+  fragment name: 'Fragment: Project Page' do
     visit name: 'project page', url: 'https://github.com/flood-io/ruby-jmeter'
   end
 

--- a/lib/ruby-jmeter/DSL.md
+++ b/lib/ruby-jmeter/DSL.md
@@ -37,6 +37,8 @@
   `tcp_sampler_config`
 - User Defined Variables
   `user_defined_variables`
+- Test Fragment Controller
+  `test_fragment_controller`
 - Thread Group
   `thread_group`
 - ForEach Controller

--- a/lib/ruby-jmeter/dsl.rb
+++ b/lib/ruby-jmeter/dsl.rb
@@ -242,6 +242,8 @@ module RubyJmeter
 
     alias_method :Once, :once_only_controller
 
+    alias_method :fragment, :test_fragment_controller
+
     ##
     # Listeners
 

--- a/lib/ruby-jmeter/dsl/test_fragment.rb
+++ b/lib/ruby-jmeter/dsl/test_fragment.rb
@@ -1,0 +1,23 @@
+module RubyJmeter
+  class DSL
+    def test_fragment(params={}, &block)
+      node = RubyJmeter::TestFragment.new(params)
+      attach_node(node, &block)
+    end
+  end
+
+  class TestFragment
+    attr_accessor :doc
+    include Helper
+
+    def initialize(params={})
+      testname = params.kind_of?(Array) ? 'TestFragmentController' : (params[:name] || 'TestFragmentController')
+      @doc = Nokogiri::XML(<<-EOS.strip_heredoc)
+<TestFragmentController guiclass="TestFragmentControllerGui" testclass="TestFragmentController" testname="#{testname}" enabled="true"/>)
+      EOS
+      update params
+      update_at_xpath params if params.is_a?(Hash) && params[:update_at_xpath]
+    end
+  end
+
+end

--- a/lib/ruby-jmeter/dsl/test_fragment_controller.rb
+++ b/lib/ruby-jmeter/dsl/test_fragment_controller.rb
@@ -1,12 +1,12 @@
 module RubyJmeter
   class DSL
-    def test_fragment(params={}, &block)
-      node = RubyJmeter::TestFragment.new(params)
+    def test_fragment_controller(params={}, &block)
+      node = RubyJmeter::TestFragmentController.new(params)
       attach_node(node, &block)
     end
   end
 
-  class TestFragment
+  class TestFragmentController
     attr_accessor :doc
     include Helper
 

--- a/lib/ruby-jmeter/idl.xml
+++ b/lib/ruby-jmeter/idl.xml
@@ -241,6 +241,8 @@
         <stringProp name="TestPlan.comments"> </stringProp>
       </Arguments>
       <hashTree/>
+      <TestFragmentController guiclass="TestFragmentControllerGui" testclass="TestFragmentController" testname="Test Fragment Controller" enabled="true" />
+      <hashTree/>
       <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group" enabled="true">
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -844,4 +844,26 @@ describe "DSL" do
     end
   end
 
+  describe 'test fragments' do
+    let(:doc) do
+      test do
+        test_fragment name: 'fred' do
+          Simple name: 'joe'
+        end
+      end.to_doc
+    end
+
+    let(:fragment) { doc.search("//TestFragmentController").first }
+
+    it 'should have a name' do
+      fragment['testname'].should == 'fred'
+    end
+
+    it 'should have a child controller' do
+      fragment.search("//GenericController").first['testname'].should == 'joe'
+    end
+
+  end
+  
+
 end

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -847,7 +847,7 @@ describe "DSL" do
   describe 'test fragments' do
     let(:doc) do
       test do
-        test_fragment name: 'fred' do
+        fragment name: 'fred' do
           Simple name: 'joe'
         end
       end.to_doc


### PR DESCRIPTION
Now that the module controller supports calling test elements, we can define test fragments at the top of the file and reference them later in the test plan. Complex user workflows can be built simply by picking which fragments to fire in a particular order, without having to duplicate a lot of code.