### PR TITLE
Support rack-style array params in query strings

### DIFF
--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -285,6 +285,14 @@ describe 'DSL' do
     it 'should match on always_encode' do
       fragment.search(".//boolProp[@name='HTTPArgument.always_encode']").text.should == 'true'
     end
+
+    it 'should match on query param name: location' do
+      fragment.search(".//stringProp[@name='Argument.name']").text.should == 'location'
+    end
+
+    it 'should match on query param value: melbourne' do
+      fragment.search(".//stringProp[@name='Argument.value']").text.should == 'melbourne'
+    end
   end
 
   describe 'visit old syntax' do

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -270,7 +270,7 @@ describe 'DSL' do
       test do
         threads do
           transaction name: "TC_01", parent: true, include_timers: true do
-            visit url: "/home?location=melbourne", always_encode: true
+            visit url: "/home?location=melbourne&location=sydney", always_encode: true
           end
         end
       end.to_doc
@@ -282,16 +282,32 @@ describe 'DSL' do
       fragment.search(".//stringProp[@name='HTTPSampler.path']").text.should == '/home'
     end
 
-    it 'should match on always_encode' do
-      fragment.search(".//boolProp[@name='HTTPArgument.always_encode']").text.should == 'true'
+    context "first argument" do
+      it 'should match on always_encode' do
+        fragment.search(".//boolProp[@name='HTTPArgument.always_encode']")[0].text.should == 'true'
+      end
+
+      it 'should match on query param name: location' do
+        fragment.search(".//stringProp[@name='Argument.name']")[0].text.should == 'location'
+      end
+
+      it 'should match on query param value: melbourne' do
+        fragment.search(".//stringProp[@name='Argument.value']")[0].text.should == 'melbourne'
+      end
     end
 
-    it 'should match on query param name: location' do
-      fragment.search(".//stringProp[@name='Argument.name']").text.should == 'location'
-    end
+    context "second argument" do
+      it 'should match on always_encode' do
+        fragment.search(".//boolProp[@name='HTTPArgument.always_encode']")[1].text.should == 'true'
+      end
 
-    it 'should match on query param value: melbourne' do
-      fragment.search(".//stringProp[@name='Argument.value']").text.should == 'melbourne'
+      it 'should match on query param name: location' do
+        fragment.search(".//stringProp[@name='Argument.name']")[1].text.should == 'location'
+      end
+
+      it 'should match on query param value: sydney' do
+        fragment.search(".//stringProp[@name='Argument.value']")[1].text.should == 'sydney'
+      end
     end
   end
 


### PR DESCRIPTION
Commonly in rack applications, array-like structures will be represented in query param pairs by a repeated name suffixed with square brackets e.g. `p[]=a&p[]=b`.

`ruby-jmeter` in its current implementation will only allow the last query param pair of an array set to be added to the resulting `jmx` file i.e. in the case of e.g. `p[]=a&p[]=b`, only `p[]=b` is added as an argument.

My PR modifies the parser to support multiple query param pairs with the same name to be added to the jmx, supporting rack endpoints that require an array structure with multiple values.