### PR TITLE
Add support for inline properties in run

### DIFF
--- a/lib/ruby-jmeter/dsl.rb
+++ b/lib/ruby-jmeter/dsl.rb
@@ -506,8 +506,7 @@ module RubyJmeter
     def run(params = {})
       file(params)
       logger.warn "Test executing locally ..."
-      properties = params.has_key?(:properties) ? params[:properties] : "#{File.dirname(__FILE__)}/helpers/jmeter.properties"
-      properties = "-q #{properties}" if properties
+      properties = params.has_key?(:properties) ? build_properties(params[:properties]) : "-q #{File.dirname(__FILE__)}/helpers/jmeter.properties"
 
       if params[:remote_hosts]
         remote_hosts = params[:remote_hosts]
@@ -615,6 +614,14 @@ module RubyJmeter
 
     def doc
       Nokogiri::XML(@root.to_s, &:noblanks)
+    end
+
+    def build_properties(properties)
+      if properties.kind_of?(String)
+        "-q #{properties}"
+      elsif properties.kind_of?(Hash)
+        properties.map{ |k,v| "-J#{k}=#{v}" }.join(" ")
+      end
     end
 
     def logger

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -823,6 +823,22 @@ describe 'DSL' do
       end.run(properties: 'my-jmeter.properties')
     end
 
+    it 'pass an inline property' do
+      Open3.should_receive(:popen2e)
+           .with('jmeter -n -t jmeter.jmx -j jmeter.log -l jmeter.jtl -Jjmeter.save.saveservice.output_format=xml ')
+
+      test do
+      end.run(properties: {"jmeter.save.saveservice.output_format" => "xml"})
+    end
+
+    it 'pass multiple inline properties' do
+      Open3.should_receive(:popen2e)
+           .with('jmeter -n -t jmeter.jmx -j jmeter.log -l jmeter.jtl -Jtlon=uqbar -Jorbis=tertius ')
+
+      test do
+      end.run(properties: {tlon: "uqbar", orbis: "tertius"})
+    end
+
     it 'do not pass a properties file' do
       Open3.should_receive(:popen2e)
            .with("jmeter -n -t jmeter.jmx -j jmeter.log -l jmeter.jtl -q #{deflate_properties} ")


### PR DESCRIPTION
It'd be nice to provide inline properties to `run` instead of having to make an entire `custom-jmeter.properties` file that may have just one or two lines.