### PR TITLE
accept filename as an argument to perfmon_collector

### DIFF
--- a/lib/ruby-jmeter/dsl.rb
+++ b/lib/ruby-jmeter/dsl.rb
@@ -468,8 +468,8 @@ module RubyJmeter
 
     alias_method :active_threads, :active_threads_over_time
 
-    def perfmon_collector(name, params = {}, &block)
-      node = RubyJmeter::Plugins::PerfmonCollector.new(name, params)
+    def perfmon_collector(name, params = {}, filename="perfMon.jtl", &block)
+      node = RubyJmeter::Plugins::PerfmonCollector.new(name, params, filename)
       attach_node(node, &block)
     end
 

--- a/lib/ruby-jmeter/plugins/perfmon_collector.rb
+++ b/lib/ruby-jmeter/plugins/perfmon_collector.rb
@@ -41,7 +41,7 @@ module RubyJmeter
                 <subresults>false</subresults>
                 <responseData>false</responseData>
                 <samplerData>false</samplerData>
-                <xml>false</xml>
+                <xml>true</xml>
                 <fieldNames>false</fieldNames>
                 <responseHeaders>false</responseHeaders>
                 <requestHeaders>false</requestHeaders>

--- a/lib/ruby-jmeter/plugins/perfmon_collector.rb
+++ b/lib/ruby-jmeter/plugins/perfmon_collector.rb
@@ -3,7 +3,7 @@ module RubyJmeter
     class PerfmonCollector
       attr_accessor :doc
       include Helper
-      def initialize(name, params={})
+      def initialize(name, params={}, filename="perfMon.jtl")
         metricNodes = params.collect do |m|
           "
             <collectionProp name=\"\">
@@ -53,7 +53,7 @@ module RubyJmeter
                 <sampleCount>true</sampleCount>
               </value>
             </objProp>
-            <stringProp name="filename"></stringProp>
+            <stringProp name="filename">#{filename}</stringProp>
             <longProp name="interval_grouping">1000</longProp>
             <boolProp name="graph_aggregated">false</boolProp>
             <stringProp name="include_sample_labels"></stringProp>


### PR DESCRIPTION
- This would enable specifying filename where the perMon results should be
	stored

- By default the results will get stored in /tmp directory with random filename. So it is difficult to differentiate the files and also integrate with the build system