### PR TITLE
Change default loop count for setup thread group (from -1 to 1)

### DIFF
--- a/lib/ruby-jmeter/dsl/setup_thread_group.rb
+++ b/lib/ruby-jmeter/dsl/setup_thread_group.rb
@@ -17,7 +17,7 @@ module RubyJmeter
   <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
   <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="#{testname}" enabled="true">
     <boolProp name="LoopController.continue_forever">false</boolProp>
-    <stringProp name="LoopController.loops">-1</stringProp>
+    <stringProp name="LoopController.loops">1</stringProp>
   </elementProp>
   <stringProp name="ThreadGroup.num_threads">1</stringProp>
   <stringProp name="ThreadGroup.ramp_time">1</stringProp>

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -189,7 +189,7 @@ describe 'DSL' do
   describe 'setup thread groups' do
     let(:doc) do
       test do
-        setup_thread_group count: 101, continue_forever: true, duration: 69
+        setup_thread_group count: 101, duration: 69, loops: 77
       end.to_doc
     end
 
@@ -204,11 +204,11 @@ describe 'DSL' do
     end
 
     it 'should match on continue_forever' do
-      fragment.search(".//boolProp[@name='LoopController.continue_forever']").text.should == 'true'
+      fragment.search(".//boolProp[@name='LoopController.continue_forever']").text.should == 'false'
     end
 
     it 'should match on loops' do
-      fragment.search(".//stringProp[@name='LoopController.loops']").text.should == '-1'
+      fragment.search(".//stringProp[@name='LoopController.loops']").text.should == '77'
     end
 
     it 'should match on duration' do


### PR DESCRIPTION
Change default loop count for setup thread group (from -1 to 1) to match the normal jmeter defaults, updated test spec to use this scenario instead.