### PR TITLE
Add redis data set config from jmeter-plugins extras with libs

### DIFF
--- a/examples/real_redis_data_set_with_setup.rb
+++ b/examples/real_redis_data_set_with_setup.rb
@@ -1,0 +1,124 @@
+################################################################################
+# This is an example of how to use a Redis data set with CSV data.
+# The test plan defines a setup thread group with a JSR223 sampler (scripted in
+# Groovy), which pre-populates Redis with the data used for the actual test.
+# The test itself simply calls a REST API with data seeded from Redis.
+#
+# The redis key is "test_data" and the format of the CSV data is:
+#   user_id,start_date,end_date
+#
+# Requires:
+#  JMeter (recommended version: 2.13 or later)
+#  jmeter-plugins extras with libs (this gives us the redis data set config)
+#  Groovy 2.4 or later (put the groovy-all jar into $JMETER_HOME/lib)
+################################################################################
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+require 'ruby-jmeter'
+
+# For redis dataset config.
+redis_host = 'localhost'
+redis_port = 6379
+redis_key = 'test_data'
+num_records = 1000 # how many rows of test data to generate
+
+# for HTTP request defaults
+protocol = 'http'
+host = 'localhost'
+port = 8080
+
+# JMeter test plan begins here.
+test do
+
+  # Setup the data set we will use to run the tests.
+  setup_thread_group name: 'Redis Fill',
+    loops: 1 do
+    jsr223_sampler name: 'redis fill',
+      scriptLanguage: 'groovy',
+      cacheKey: 'prefill_user_ids',
+      script: <<-EOS.strip_heredoc
+import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.Jedis;
+
+import java.util.Random;
+import java.util.Date;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+JedisPoolConfig config = new JedisPoolConfig();
+JedisPool pool = new JedisPool(config, "#{redis_host}", #{redis_port});
+Jedis jedis = null;
+try {
+    jedis = pool.getResource();
+
+    //delete old data, if it exists
+    jedis.del("#{redis_key}");
+
+    // Create a list of the last 90 days. We will seed our test data from this.
+    Date now = new Date();
+    Date oldest = now - 90;
+    Range days = oldest..now;
+
+    Random random = new Random();
+    DateFormat df = new SimpleDateFormat("yyyy-MM-dd");
+
+    /*
+     * Generate CSV data in the form of:
+     *   user_id,start_date,end_date
+     */
+    for (int i = 1; i <= #{num_records}; i++) {
+        Date day = days[random.nextInt(days.size())]
+        String data = [i, df.format(day), df.format(day)].join(',')
+        jedis.sadd("#{redis_key}", data);
+    }
+}finally {
+    if(jedis != null) {
+        pool.returnResource(jedis);
+    }
+}
+        EOS
+  end
+
+  # Defines a thread group. We allow certain parameters to be passed in
+  # as system properties.
+  threads name: 'Test Scenario - REST API query',
+    count: '${__P(threads,1)}',
+    rampup: '${__P(rampup,600)}',
+    duration: '${__P(duration, 600)}' do
+
+    # HTTP request defaults
+    defaults domain: host, # default domain if not specified in URL
+      protocol: protocol, # default protocol if not specified in URL
+      port: port,
+      download_resources: false # download images/CSS/JS (no)
+
+    cookies # om nom nom
+
+    cache clear_each_iteration: true # each thread iteration mimics a new user with an empty browser cache
+
+    with_gzip # add HTTP request headers to allow GZIP compression. Most sites support this nowadays.
+
+    # Test data. Note how the variableNames match the variables used by the
+    # sampler below.
+    redis_data_set 'test data',
+      redisKey: redis_key,
+      host: redis_host,
+      port: redis_port,
+      variableNames: 'user_id,start_date,end_date'
+
+    # User workflow begins here.
+    # Note that think times are defined inside the page methods.
+    visit name: 'REST API query',
+      url: '/rest/query',
+      always_encode: true,
+      fill_in: {
+        'user_id' => '${user_id}',
+        'start' => '${start_date}',
+        'end' => '${end_date}'
+      }
+  end
+
+  response_time_graph
+  view_results_tree
+end.jmx(file: 'real_redis_data_set_with_setup.jmx')

--- a/lib/ruby-jmeter/dsl.rb
+++ b/lib/ruby-jmeter/dsl.rb
@@ -519,6 +519,11 @@ module RubyJmeter
 
     alias_method :loadosophia, :loadosophia_uploader
 
+    def redis_data_set(name = "Redis Data Set Config", params = {}, &block)
+      node = RubyJmeter::Plugins::RedisDataSet.new(name, params)
+      attach_node(node, &block)
+    end
+
 
 
     # API Methods

--- a/lib/ruby-jmeter/dsl.rb
+++ b/lib/ruby-jmeter/dsl.rb
@@ -519,8 +519,8 @@ module RubyJmeter
 
     alias_method :loadosophia, :loadosophia_uploader
 
-    def redis_data_set(name = "Redis Data Set Config", params = {}, &block)
-      node = RubyJmeter::Plugins::RedisDataSet.new(name, params)
+    def redis_data_set(params = {}, &block)
+      node = RubyJmeter::Plugins::RedisDataSet.new(params)
       attach_node(node, &block)
     end
 

--- a/lib/ruby-jmeter/plugins/redis_data_set.rb
+++ b/lib/ruby-jmeter/plugins/redis_data_set.rb
@@ -1,0 +1,38 @@
+module RubyJmeter
+  module Plugins
+    class RedisDataSet
+      attr_accessor :doc
+      include Helper
+      def initialize(name, params={})
+        params[:getMode] ||= "1" unless params[:remove] == true
+        @doc = Nokogiri::XML(<<-XML.strip_heredoc)
+          <kg.apc.jmeter.config.redis.RedisDataSet guiclass="TestBeanGUI" testclass="kg.apc.jmeter.config.redis.RedisDataSet" testname="#{name}" enabled="true">
+            <stringProp name="database">0</stringProp>
+            <stringProp name="delimiter">,</stringProp>
+            <intProp name="getMode">0</intProp>
+            <stringProp name="host"></stringProp
+            <intProp name="maxActive">20</intProp>
+            <intProp name="maxIdle">10</intProp>
+            <longProp name="maxWait">30000</longProp>
+            <longProp name="minEvictableIdleTimeMillis">60000</longProp>
+            <intProp name="minIdle">0</intProp>
+            <intProp name="numTestsPerEvictionRun">0</intProp>
+            <stringProp name="password"></stringProp>
+            <stringProp name="port">6379</stringProp>
+            <stringProp name="redisKey"></stringProp>
+            <longProp name="softMinEvictableIdleTimeMillis">60000</longProp>
+            <boolProp name="testOnBorrow">false</boolProp>
+            <boolProp name="testOnReturn">false</boolProp>
+            <boolProp name="testWhileIdle">false</boolProp>
+            <longProp name="timeBetweenEvictionRunsMillis">30000</longProp>
+            <stringProp name="timeout">2000</stringProp>
+            <stringProp name="variableNames"></stringProp>
+            <intProp name="whenExhaustedAction">2</intProp>
+          </kg.apc.jmeter.config.redis.RedisDataSet>
+        XML
+        update params
+        update_at_xpath params if params.is_a?(Hash) && params[:update_at_xpath]
+      end
+    end
+  end
+end

--- a/lib/ruby-jmeter/plugins/redis_data_set.rb
+++ b/lib/ruby-jmeter/plugins/redis_data_set.rb
@@ -3,10 +3,11 @@ module RubyJmeter
     class RedisDataSet
       attr_accessor :doc
       include Helper
-      def initialize(name, params={})
+      def initialize(params={})
+        testname = params.kind_of?(Array) ? 'Redis Data Set Config' : (params[:name] || 'Redis Data Set Config')
         params[:getMode] ||= "1" unless params[:remove] == true
         @doc = Nokogiri::XML(<<-XML.strip_heredoc)
-          <kg.apc.jmeter.config.redis.RedisDataSet guiclass="TestBeanGUI" testclass="kg.apc.jmeter.config.redis.RedisDataSet" testname="#{name}" enabled="true">
+          <kg.apc.jmeter.config.redis.RedisDataSet guiclass="TestBeanGUI" testclass="kg.apc.jmeter.config.redis.RedisDataSet" testname="#{testname}" enabled="true">
             <stringProp name="database">0</stringProp>
             <stringProp name="delimiter">,</stringProp>
             <intProp name="getMode">0</intProp>

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -1107,7 +1107,7 @@ describe 'DSL' do
         let(:doc) do
           test do
             threads do
-              redis_data_set 'redis data set name',
+              redis_data_set name: 'redis data set name',
                 host: 'the_host',
                 port: 1234
 
@@ -1138,15 +1138,15 @@ describe 'DSL' do
         let(:doc) do
           test do
             threads do
-              redis_data_set 'redis data set remove', remove: true
+              redis_data_set remove: true
             end
           end.to_doc
         end
 
         let(:fragment) { doc.search("//kg.apc.jmeter.config.redis.RedisDataSet").first }
 
-        it 'should have a name' do
-          fragment.attributes['testname'].value.should == 'redis data set remove'
+        it 'should have a default name' do
+          fragment.attributes['testname'].value.should == 'Redis Data Set Config'
         end
 
         it 'should be configured for random remove' do

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -1101,4 +1101,57 @@ describe 'DSL' do
         metric_connections.search("//stringProp[@name='']").first.text.should == '1.1.1.1'
       end
     end
+
+    describe 'redis data set' do
+      describe 'random keep' do
+        let(:doc) do
+          test do
+            threads do
+              redis_data_set 'redis data set name',
+                host: 'the_host',
+                port: 1234
+
+            end
+          end.to_doc
+        end
+
+        let(:fragment) { doc.search("//kg.apc.jmeter.config.redis.RedisDataSet").first }
+
+        it 'should have a name' do
+          fragment.attributes['testname'].value.should == 'redis data set name'
+        end
+
+        it 'should be configured for random keep' do
+          fragment.search("//intProp[@name='getMode']").text.should == '1'
+        end
+
+        it 'should point to the host' do
+          fragment.search("//stringProp[@name='host']").text.should == 'the_host'
+        end
+
+        it 'should configure a port' do
+          fragment.search("//stringProp[@name='port']").text.should == '1234'
+        end
+      end
+
+      describe 'random remove' do
+        let(:doc) do
+          test do
+            threads do
+              redis_data_set 'redis data set remove', remove: true
+            end
+          end.to_doc
+        end
+
+        let(:fragment) { doc.search("//kg.apc.jmeter.config.redis.RedisDataSet").first }
+
+        it 'should have a name' do
+          fragment.attributes['testname'].value.should == 'redis data set remove'
+        end
+
+        it 'should be configured for random remove' do
+          fragment.search("//intProp[@name='getMode']").text.should == '0'
+        end
+      end
+    end
 end


### PR DESCRIPTION
This PR adds DSL support for the [Redis Data Set](http://jmeter-plugins.org/wiki/RedisDataSet/) from jmeter plugins' extras with libs set.

It also shows a working example of the redis data set, including a setup thread group with a groovy script for preseeding the redis data.