### PR TITLE
User defined cookies

### DIFF
--- a/lib/ruby-jmeter/dsl/http_cookie_manager.rb
+++ b/lib/ruby-jmeter/dsl/http_cookie_manager.rb
@@ -12,9 +12,10 @@ module RubyJmeter
 
     def initialize(params={})
       testname = params.kind_of?(Array) ? 'HttpCookieManager' : (params[:name] || 'HttpCookieManager')
+      cookie_jar = user_defined_cookies(params[:user_cookies]) if params.include? :user_cookies
       @doc = Nokogiri::XML(<<-EOS.strip_heredoc)
 <CookieManager guiclass="CookiePanel" testclass="CookieManager" testname="#{testname}" enabled="true">
-  <collectionProp name="CookieManager.cookies"/>
+  <collectionProp name="CookieManager.cookies">#{cookie_jar}</collectionProp
   <boolProp name="CookieManager.clearEachIteration">false</boolProp>
   <stringProp name="CookieManager.policy">default</stringProp>
   <stringProp name="CookieManager.implementation">org.apache.jmeter.protocol.http.control.HC4CookieHandler</stringProp>
@@ -22,6 +23,34 @@ module RubyJmeter
       EOS
       update params
       update_at_xpath params if params.is_a?(Hash) && params[:update_at_xpath]
+    end
+
+    def user_defined_cookies(user_cookies)
+      cookie_jar = ""
+      if user_cookies.is_a?(Hash)
+        user_cookies.each do |name, attrs|
+          value = attrs.fetch(:value, "")
+          domain = attrs.fetch(:domain, "")
+          path = attrs.fetch(:path, "")
+          secure = attrs.fetch(:secure, false)
+          expires = attrs.fetch(:expires, 0)
+          path_specified = path.present?
+          domain_specified = domain.present?
+          element = <<-EOS.strip_heredoc
+<elementProp name="#{name}" elementType="Cookie" testname="#{name}">
+  <stringProp name="Cookie.value">#{value}</stringProp>
+  <stringProp name="Cookie.domain">#{domain}</stringProp>
+  <stringProp name="Cookie.path">#{path}</stringProp>
+  <boolProp name="Cookie.secure">#{secure}</boolProp>
+  <longProp name="Cookie.expires">#{expires}</longProp>
+  <boolProp name="Cookie.path_specified">#{path_specified}</boolProp>
+  <boolProp name="Cookie.domain_specified">#{domain_specified}</boolProp>
+</elementProp>
+          EOS
+          cookie_jar << element
+        end
+      end
+      cookie_jar
     end
   end
 

--- a/lib/ruby-jmeter/dsl/http_cookie_manager.rb
+++ b/lib/ruby-jmeter/dsl/http_cookie_manager.rb
@@ -34,8 +34,8 @@ module RubyJmeter
           path = attrs.fetch(:path, "")
           secure = attrs.fetch(:secure, false)
           expires = attrs.fetch(:expires, 0)
-          path_specified = path.present?
-          domain_specified = domain.present?
+          path_specified = !path.empty?
+          domain_specified = !domain.empty?
           element = <<-EOS.strip_heredoc
 <elementProp name="#{name}" elementType="Cookie" testname="#{name}">
   <stringProp name="Cookie.value">#{value}</stringProp>

--- a/spec/http_cookie_manager_spec.rb
+++ b/spec/http_cookie_manager_spec.rb
@@ -14,4 +14,22 @@ describe 'http_cookie_manager' do
       expect(cookies_fragment.search(".//boolProp[@name='CookieManager.clearEachIteration']").first.text).to eq'true'
     end
   end
+
+  describe 'the user_cookies option allows for user defined cookies to be used' do
+    let(:doc) do
+      test do
+        cookies user_cookies: { origin: { value: "jmeter", domain: 'domain' } }
+      end.to_doc
+    end
+
+    let(:cookies_fragment) { doc.search("//CookieManager") }
+
+    it 'has a "cookie jar" in the document' do
+      expect(cookies_fragment.search(".//collectionProp[@name='CookieManager.cookies']").first).not_to be_nil
+    end
+
+    it 'should have created cookie in document' do
+      expect(cookies_fragment.search(".//collectionProp[@name='CookieManager.cookies']").first.search(".//elementProp[@name='origin']")).not_to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Added a method that would allow to pass in a hash called `user_cookies`, this has may hash's key will be taken as the name of the cookie, and a hash with all the other values to be used, options available in JMeter docs
