### PR TITLE
Fix issue when ExtendedDSL#run's path: option doesn't end with a '/'

### DIFF
--- a/lib/ruby-jmeter/dsl.rb
+++ b/lib/ruby-jmeter/dsl.rb
@@ -38,7 +38,7 @@ module RubyJmeter
       file(params)
       logger.warn 'Test executing locally ...'
 
-      cmd = "#{params[:path]}jmeter #{"-n" unless params[:gui] } -t #{params[:file]} -j #{params[:log] ? params[:log] : 'jmeter.log' } -l #{params[:jtl] ? params[:jtl] : 'jmeter.jtl' }"
+      cmd = "#{params[:path] ? File.join(params[:path], 'jmeter') : 'jmeter'} #{"-n" unless params[:gui] } -t #{params[:file]} -j #{params[:log] ? params[:log] : 'jmeter.log' } -l #{params[:jtl] ? params[:jtl] : 'jmeter.jtl' }"
       logger.debug cmd if params[:debug]
       Open3.popen2e("#{cmd}") do |stdin, stdout_err, wait_thr|
         while line = stdout_err.gets


### PR DESCRIPTION
If you forget to put a `'/'` (on UNIX) at the end of your `path:` option for `ExtendedDSL#run` it will fail regardless if the directory exists or not. For instance `test { }.run(path: '/path/to/jmeter/bin/')` is acceptable but `test{ }.run(path: '/path/to/jmeter/bin')` will always fail.

This PR fixes that issue.

