### PR TITLE
Modify the doubleProp to a stringProp in constant_throughput_timer

### DIFF
--- a/lib/ruby-jmeter/dsl/constant_throughput_timer.rb
+++ b/lib/ruby-jmeter/dsl/constant_throughput_timer.rb
@@ -15,11 +15,7 @@ module RubyJmeter
       @doc = Nokogiri::XML(<<-EOS.strip_heredoc)
 <ConstantThroughputTimer guiclass="TestBeanGUI" testclass="ConstantThroughputTimer" testname="#{testname}" enabled="true">
   <intProp name="calcMode">0</intProp>
-  <doubleProp>
-    <name>throughput</name>
-    <value>0.0</value>
-    <savedValue>0.0</savedValue>
-  </doubleProp>
+  <stringProp name="throughput">0.0</stringProp>
 </ConstantThroughputTimer>)
       EOS
       update params

--- a/lib/ruby-jmeter/extend/timers/constant_throughput_timer.rb
+++ b/lib/ruby-jmeter/extend/timers/constant_throughput_timer.rb
@@ -4,8 +4,7 @@ module RubyJmeter
       params[:value] ||= params[:throughput] || 0.0
 
       node = RubyJmeter::ConstantThroughputTimer.new(params)
-      node.doc.xpath('.//value').first.content = params[:value].to_f
-
+      node.doc.xpath('//stringProp[@name="throughput"]').first.content = params[:value]
       attach_node(node, &block)
     end
   end

--- a/lib/ruby-jmeter/idl.xml
+++ b/lib/ruby-jmeter/idl.xml
@@ -340,11 +340,7 @@
         <hashTree/>
         <ConstantThroughputTimer guiclass="TestBeanGUI" testclass="ConstantThroughputTimer" testname="Constant Throughput Timer" enabled="true">
           <intProp name="calcMode">0</intProp>
-          <doubleProp>
-            <name>throughput</name>
-            <value>0.0</value>
-            <savedValue>0.0</savedValue>
-          </doubleProp>
+          <stringProp name="throughput">0.0</stringProp>
         </ConstantThroughputTimer>
         <hashTree/>
         <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Constant Timer" enabled="true">

--- a/spec/constant_throughput_timer_spec.rb
+++ b/spec/constant_throughput_timer_spec.rb
@@ -10,13 +10,11 @@ describe 'constant_throughput_timer' do
     end.to_doc
   end
 
-  let(:fragment) { doc.search("//ConstantThroughputTimer").first }
-
   it 'should match on throughput using value' do
-    expect(fragment.search("//doubleProp/value").first.text).to eq '60.0'
+    expect(doc.search('//ConstantThroughputTimer[1]/stringProp[@name="throughput"]').first.content).to eq '60.0'
   end
-
+  
   it 'should match on throughput using throughput' do
-    expect(fragment.search("//doubleProp/value").last.text).to eq '70.0'
+    expect(doc.search('//ConstantThroughputTimer[2]/stringProp[@name="throughput"]').first.content).to eq '70.0'
   end
 end


### PR DESCRIPTION
Modify the type of the throughput field from double to string so that it can take variables I.E '{$mythroughput}'. Previous this change if you tried to use a variable in that way ruby-jmeter would change it to 0.0.
