### PR TITLE
Add additional JMeter properties via properties param

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ test do
 end.run
 ```
 
-This will launch JMeter in headless (non-GUI mode) and execute the test plan. This is useful for shaking out the script before you push it to the Grid. There are a few parameters that you can set such as the `path` to the JMeter binary, the `file` path/name for the JMX file, the `log` path/name to output JMeter logs, the `jtl` path/name for JMeter results like this, the `properties` path/name for the additional JMeter property file.
+This will launch JMeter in headless (non-GUI mode) and execute the test plan. This is useful for shaking out the script before you push it to the Grid. There are a few parameters that you can set such as the `path` to the JMeter binary, the `file` path/name for the JMX file, the `log` path/name to output JMeter logs, the `jtl` path/name for JMeter results like this, and the `properties` path/name for the additional JMeter property file.
 
 ```ruby
 test do

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ test do
 end.run
 ```
 
-This will launch JMeter in headless (non-GUI mode) and execute the test plan. This is useful for shaking out the script before you push it to the Grid. There are a few parameters that you can set such as the `path` to the JMeter binary, the `file` path/name for the JMX file, the `log` path/name to output JMeter logs and the `jtl` path/name for JMeter results like this.
+This will launch JMeter in headless (non-GUI mode) and execute the test plan. This is useful for shaking out the script before you push it to the Grid. There are a few parameters that you can set such as the `path` to the JMeter binary, the `file` path/name for the JMX file, the `log` path/name to output JMeter logs, the `jtl` path/name for JMeter results like this, the `properties` path/name for the additional JMeter property file.
 
 ```ruby
 test do
@@ -97,7 +97,8 @@ end.run(
   path: '/usr/share/jmeter/bin/',
   file: 'jmeter.jmx',
   log: 'jmeter.log',
-  jtl: 'results.jtl')
+  jtl: 'results.jtl',
+  properties: 'jmeter.properties')
 ```
 
 ### Running a JMeter Test Plan on Flood IO

--- a/lib/ruby-jmeter/dsl.rb
+++ b/lib/ruby-jmeter/dsl.rb
@@ -38,7 +38,7 @@ module RubyJmeter
       file(params)
       logger.warn 'Test executing locally ...'
 
-      cmd = "#{params[:path]}jmeter #{"-n" unless params[:gui] } -t #{params[:file]} -j #{params[:log] ? params[:log] : 'jmeter.log' } -l #{params[:jtl] ? params[:jtl] : 'jmeter.jtl' }"
+      cmd = "#{params[:path]}jmeter #{"-n" unless params[:gui] } -t #{params[:file]} -j #{params[:log] ? params[:log] : 'jmeter.log' } -l #{params[:jtl] ? params[:jtl] : 'jmeter.jtl' } #{build_properties(params[:properties]) if params[:properties]}"
       logger.debug cmd if params[:debug]
       Open3.popen2e("#{cmd}") do |stdin, stdout_err, wait_thr|
         while line = stdout_err.gets
@@ -79,6 +79,14 @@ module RubyJmeter
 
     def doc
       Nokogiri::XML(@root.to_s, &:noblanks)
+    end
+
+    def build_properties(properties)
+      if properties.kind_of?(String)
+        "-q #{properties}"
+      elsif properties.kind_of?(Hash)
+        properties.map{ |k,v| "-J#{k}=#{v}" }.join(" ")
+      end
     end
 
     def logger


### PR DESCRIPTION
Reintroduces the ability to add additional JMeter properties as parameters of `run`, either in a file or as a hashmap. 