### PR TITLE
JMXMon Sample Collector plugin support 

### DIFF
--- a/lib/ruby-jmeter/extend/plugins/jmeter_plugins.rb
+++ b/lib/ruby-jmeter/extend/plugins/jmeter_plugins.rb
@@ -111,5 +111,10 @@ module RubyJmeter
       node = RubyJmeter::Plugins::RedisDataSet.new(params)
       attach_node(node, &block)
     end
+
+    def jmx_collector(params = {}, &block)
+      node = RubyJmeter::Plugins::JMXCollector.new(params)
+      attach_node(node, &block)
+    end
   end
 end

--- a/lib/ruby-jmeter/plugins/jmx_collector.rb
+++ b/lib/ruby-jmeter/plugins/jmx_collector.rb
@@ -1,0 +1,72 @@
+module RubyJmeter
+  module Plugins
+    class JMXCollector
+      attr_accessor :doc
+      include Helper
+      def initialize(params={})
+        
+        params[:name] ||= 'JMX Collector'
+        params[:jtl] ||= ''
+
+        @doc = Nokogiri::XML(<<-XML.strip_heredoc)
+        <kg.apc.jmeter.jmxmon.JMXMonCollector guiclass="kg.apc.jmeter.vizualizers.JMXMonGui" testclass="kg.apc.jmeter.jmxmon.JMXMonCollector" testname="#{params[:name]}" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+            </value>
+          </objProp>
+          <stringProp name="filename">#{params[:jtl]}</stringProp>
+          <longProp name="interval_grouping">1000</longProp>
+          <boolProp name="graph_aggregated">false</boolProp>
+          <stringProp name="include_sample_labels"></stringProp>
+          <stringProp name="exclude_sample_labels"></stringProp>
+          <stringProp name="start_offset"></stringProp>
+          <stringProp name="end_offset"></stringProp>
+          <boolProp name="include_checkbox_state">false</boolProp>
+          <boolProp name="exclude_checkbox_state">false</boolProp>
+          <collectionProp name="samplers">
+            <collectionProp name="311458936">
+              <stringProp name="0"></stringProp>
+              <stringProp name="-1685784265">service:jmx:rmi:///jndi/rmi://#{params[:host]}:#{params[:port]}/jmxrmi</stringProp>
+              <stringProp name="0"></stringProp>
+              <stringProp name="0"></stringProp>
+              <stringProp name="-1508861468">java.lang:type=#{params[:object_name]}</stringProp>
+              <stringProp name="-687755404">#{params[:attribute_name]}</stringProp>
+              <stringProp name="3599293">#{params[:attribute_key]}</stringProp>
+              <stringProp name="1237">false</stringProp>
+              <stringProp name="1231">true</stringProp>
+            </collectionProp>
+          </collectionProp>
+        </kg.apc.jmeter.jmxmon.JMXMonCollector>
+        XML
+      end
+    end
+  end
+end
+
+

--- a/lib/ruby-jmeter/plugins/jmx_collector.rb
+++ b/lib/ruby-jmeter/plugins/jmx_collector.rb
@@ -42,7 +42,7 @@ module RubyJmeter
             </value>
           </objProp>
           <stringProp name="filename">#{params[:jtl]}</stringProp>
-          <longProp name="interval_grouping">1000</longProp>
+          <longProp name="interval_grouping">1000</longProp
           <boolProp name="graph_aggregated">false</boolProp>
           <stringProp name="include_sample_labels"></stringProp>
           <stringProp name="exclude_sample_labels"></stringProp>
@@ -52,15 +52,15 @@ module RubyJmeter
           <boolProp name="exclude_checkbox_state">false</boolProp>
           <collectionProp name="samplers">
             <collectionProp name="311458936">
-              <stringProp name="0"></stringProp>
-              <stringProp name="-1685784265">service:jmx:rmi:///jndi/rmi://#{params[:host]}:#{params[:port]}/jmxrmi</stringProp>
-              <stringProp name="0"></stringProp>
-              <stringProp name="0"></stringProp>
-              <stringProp name="-1508861468">java.lang:type=#{params[:object_name]}</stringProp>
-              <stringProp name="-687755404">#{params[:attribute_name]}</stringProp>
-              <stringProp name="3599293">#{params[:attribute_key]}</stringProp>
-              <stringProp name="1237">false</stringProp>
-              <stringProp name="1231">true</stringProp>
+              <stringProp name="label"></stringProp>
+              <stringProp name="service_endpoint">service:jmx:rmi:///jndi/rmi://#{params[:host]}:#{params[:port]}/jmxrmi</stringProp>
+              <stringProp name="username"></stringProp>
+              <stringProp name="password"></stringProp>
+              <stringProp name="object_name">#{params[:object_name]}</stringProp>
+              <stringProp name="attribute_name">#{params[:attribute_name]}</stringProp>
+              <stringProp name="attribute_key">#{params[:attribute_key]}</stringProp>
+              <stringProp name="delta">false</stringProp>
+              <stringProp name="retry">true</stringProp>
             </collectionProp>
           </collectionProp>
         </kg.apc.jmeter.jmxmon.JMXMonCollector>

--- a/lib/ruby-jmeter/plugins/jmx_collector.rb
+++ b/lib/ruby-jmeter/plugins/jmx_collector.rb
@@ -4,7 +4,7 @@ module RubyJmeter
       attr_accessor :doc
       include Helper
       def initialize(params={})
-        
+
         params[:name] ||= 'JMX Collector'
         params[:jtl] ||= ''
 

--- a/lib/ruby-jmeter/plugins/jmx_collector.rb
+++ b/lib/ruby-jmeter/plugins/jmx_collector.rb
@@ -7,6 +7,7 @@ module RubyJmeter
 
         params[:name] ||= 'JMX Collector'
         params[:jtl] ||= ''
+        params[:attribute_key] ||= ''
 
         @doc = Nokogiri::XML(<<-XML.strip_heredoc)
         <kg.apc.jmeter.jmxmon.JMXMonCollector guiclass="kg.apc.jmeter.vizualizers.JMXMonGui" testclass="kg.apc.jmeter.jmxmon.JMXMonCollector" testname="#{params[:name]}" enabled="true">

--- a/lib/ruby-jmeter/version.rb
+++ b/lib/ruby-jmeter/version.rb
@@ -1,3 +1,3 @@
 module RubyJmeter
-  VERSION = '3.0.10'
+  VERSION = '3.0.11'
 end

--- a/spec/jmeter_plugins_spec.rb
+++ b/spec/jmeter_plugins_spec.rb
@@ -153,3 +153,93 @@ describe 'redis data set' do
     end
   end
 end
+
+describe 'jmx collector' do
+
+  describe 'passing all optionals' do
+    let(:doc) do
+      test do
+        jmx_collector(
+            name: 'some jmx collector name',
+            host: 'localhost',
+            port: 12345,
+            object_name: 'java.lang:type=Memory',
+            attribute_name: 'HeapMemoryUsage',
+            attribute_key: 'committed',
+            jtl: 'path/to/some/dir/file.jtl'
+        )
+      end.to_doc
+    end
+
+    let(:fragment) {
+      doc.search('//kg.apc.jmeter.jmxmon.JMXMonCollector').first }
+
+    it 'should have a name' do
+      expect(fragment.attributes['testname'].value).to eq 'some jmx collector name'
+    end
+
+    it 'should point to the service endpoint' do
+      expect(fragment.search("//stringProp[@name='service_endpoint']").text).to eq 'service:jmx:rmi:///jndi/rmi://localhost:12345/jmxrmi'
+    end
+
+    it 'should use the object name' do
+      expect(fragment.search("//stringProp[@name='object_name']").text).to eq 'java.lang:type=Memory'
+    end
+
+    it 'should use the attribute name' do
+      expect(fragment.search("//stringProp[@name='attribute_name']").text).to eq 'HeapMemoryUsage'
+    end
+
+    it 'should use the attribute key' do
+      expect(fragment.search("//stringProp[@name='attribute_key']").text).to eq 'committed'
+    end
+
+    it 'should use the jtl path' do
+      expect(fragment.search("//stringProp[@name='filename']").text).to eq 'path/to/some/dir/file.jtl'
+    end
+
+  end
+
+  describe 'passing no optionals' do
+    let(:doc) do
+      test do
+        jmx_collector(
+            host: '127.0.0.1',
+            port: 54321,
+            object_name: 'java.lang:type=Threading',
+            attribute_name: 'ThreadCount',
+        )
+      end.to_doc
+    end
+
+    let(:fragment) {
+      doc.search('//kg.apc.jmeter.jmxmon.JMXMonCollector').first }
+
+    it 'should have a default name' do
+      expect(fragment.attributes['testname'].value).to eq 'JMX Collector'
+    end
+
+    it 'should point to the service endpoint' do
+      expect(fragment.search("//stringProp[@name='service_endpoint']").text).to eq 'service:jmx:rmi:///jndi/rmi://127.0.0.1:54321/jmxrmi'
+    end
+
+    it 'should use the object name' do
+      expect(fragment.search("//stringProp[@name='object_name']").text).to eq 'java.lang:type=Threading'
+    end
+
+    it 'should use the attribute name' do
+      expect(fragment.search("//stringProp[@name='attribute_name']").text).to eq 'ThreadCount'
+    end
+
+    it 'should use an empty attribute key' do
+      expect(fragment.search("//stringProp[@name='attribute_key']").text).to eq ''
+    end
+
+    it 'should use an empty jtl path' do
+      expect(fragment.search("//stringProp[@name='filename']").text).to eq ''
+    end
+
+  end
+
+end
+


### PR DESCRIPTION
Added support for the JMXMon Sample Collector plugin (https://jmeter-plugins.org/wiki/JMXMon/).

Usage example:

``` ruby
        jmx_collector(
            host: 'localhost',
            port: 10000,
            object_name: 'Threading',
            attribute_name: 'ThreadCount',
            jtl: "#{results_dir}/thread_count_jmx.jtl"
        )
```
