### PR TITLE
Default blank JMS sampler property name and value

### DIFF
--- a/lib/ruby-jmeter/idl.xml
+++ b/lib/ruby-jmeter/idl.xml
@@ -609,13 +609,7 @@
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
           <elementProp name="arguments" elementType="JMSProperties">
-            <collectionProp name="JMSProperties.properties">
-              <elementProp name="" elementType="JMSProperty">
-                <stringProp name="JMSProperty.name"> </stringProp>
-                <stringProp name="JMSProperty.value"></stringProp>
-                <stringProp name="JMSProperty.type">java.lang.String</stringProp>
-              </elementProp>
-            </collectionProp>
+            <collectionProp name="JMSProperties.properties"/>
           </elementProp>
         </JMSSampler>
         <hashTree/>
@@ -634,14 +628,8 @@
           <stringProp name="jms.config_msg_type">jms_text_message</stringProp>
           <stringProp name="jms.iterations">1</stringProp>
           <boolProp name="jms.authenticate">false</boolProp>
-          <elementProp name="jms.jmsProperties" elementType="JMSProperties">
-            <collectionProp name="JMSProperties.properties">
-              <elementProp name="" elementType="JMSProperty">
-                <stringProp name="JMSProperty.name"> </stringProp>
-                <stringProp name="JMSProperty.value"></stringProp>
-                <stringProp name="JMSProperty.type">java.lang.String</stringProp>
-              </elementProp>
-            </collectionProp>
+          <elementProp name="arguments" elementType="JMSProperties">
+            <collectionProp name="JMSProperties.properties"/>
           </elementProp>
           <stringProp name="jms.expiration"></stringProp>
           <stringProp name="jms.priority"></stringProp>


### PR DESCRIPTION
For some reason - adding a JMS pointtopoint or JMS publisher sampler includes a blank name/value entry in the JMS properties. This causes a problem as Jmeter complains about this blank entry and won't execute the test.

I have replaced the JMS properties XML with what should be the default XML from Jmeter.