### PR TITLE
Add inverse assertion to json_path_assertion plugin

### DIFF
--- a/lib/ruby-jmeter/plugins/json_path_assertion.rb
+++ b/lib/ruby-jmeter/plugins/json_path_assertion.rb
@@ -9,6 +9,7 @@ module RubyJmeter
             <stringProp name="EXPECTED_VALUE"></stringProp>
             <stringProp name="JSON_PATH"></stringProp>
             <boolProp name="JSONVALIDATION">true</boolProp>
+            <boolProp name="INVERT">false</boolProp>
           </com.atlantbh.jmeter.plugins.jsonutils.jsonpathassertion.JSONPathAssertion>
         EOF
         update params


### PR DESCRIPTION
Is optional and by default set to false