### PR TITLE
Support ignoreFirstLine in csv_data_set_config

### DIFF
--- a/lib/ruby-jmeter/dsl/csv_data_set_config.rb
+++ b/lib/ruby-jmeter/dsl/csv_data_set_config.rb
@@ -21,6 +21,7 @@ module RubyJmeter
   <boolProp name="recycle">true</boolProp>
   <stringProp name="shareMode">shareMode.all</stringProp>
   <boolProp name="stopThread">false</boolProp>
+  <boolProp name="ignoreFirstLine">false</boolProp>
   <stringProp name="variableNames"/>
 </CSVDataSet>)
       EOS

--- a/spec/csv_data_set_config_spec.rb
+++ b/spec/csv_data_set_config_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe 'csv_data_set_config' do
+  describe 'the options should be respected' do
+    let(:doc) do
+      test do
+        csv_data_set_config delimiter: '|',
+                            filename: 'test.csv',
+                            ignoreFirstLine: true,
+                            variableNames: 'test1,test2'
+      end.to_doc
+    end
+
+    let(:csv_data_set) { doc.search("//CSVDataSet") }
+
+    it 'should match on variableNames' do
+      expect(csv_data_set.search(".//stringProp[@name='variableNames']").first.text).to eq 'test1,test2'
+    end
+
+    it 'should match on delimiter' do
+      expect(csv_data_set.search(".//stringProp[@name='delimiter']").first.text).to eq '|'
+    end
+
+    it 'should match on filename' do
+      expect(csv_data_set.search(".//stringProp[@name='filename']").first.text).to eq 'test.csv'
+    end
+
+    it 'should match on ignoreFirstLine' do
+      expect(csv_data_set.search(".//boolProp[@name='ignoreFirstLine']").first.text).to eq 'true'
+    end
+  end
+
+end


### PR DESCRIPTION
Hey @90kts!

I happened to be using the `ignoreFirstLine` flag and realised that the generated .jmx file didn't pick up on that change. Added a small test as well.