### PR TITLE
Supporting command_args extension on os_process_sampler

### DIFF
--- a/examples/OS_process_sampler.rb
+++ b/examples/OS_process_sampler.rb
@@ -1,24 +1,7 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'ruby-jmeter'
 
-build_args = ->(args) do
-  args.collect do |arg|
-    {
-      xpath: "//collectionProp[@name='Arguments.arguments']",
-      value: Nokogiri::XML(<<-EOF.strip_heredoc).children
-              <elementProp name="" elementType="Argument">
-                <stringProp name="Argument.name"></stringProp>
-                <stringProp name="Argument.value">#{arg}</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-            EOF
-    }
-  end
-end
-
-
 test do
-  os_process_sampler 'SystemSampler.command' => 'git',
-                      update_at_xpath: build_args.call(['push', 'origin', 'master'])
+  os_process_sampler 'SystemSampler.command' => 'git', command_args: ['push', 'origin', 'master']
 
 end.run(path: '/usr/share/jmeter/bin/', gui: true)

--- a/lib/ruby-jmeter/extend/samplers/os_process_sampler.rb
+++ b/lib/ruby-jmeter/extend/samplers/os_process_sampler.rb
@@ -1,0 +1,29 @@
+module RubyJmeter
+  module OsProcessSamplerBuildArgs
+    def initialize(params = {})
+      super
+      update_at_xpath build_args_xpath_update(params[:command_args] || {})
+    end
+
+    def build_args_xpath_update(args)
+      {
+        update_at_xpath: args.collect do |arg|
+            {
+              xpath: "//collectionProp[@name='Arguments.arguments']",
+              value: Nokogiri::XML(<<-EOF.strip_heredoc).children
+                                      <elementProp name="" elementType="Argument">
+                                        <stringProp name="Argument.name"></stringProp>
+                                        <stringProp name="Argument.value">#{arg}</stringProp>
+                                        <stringProp name="Argument.metadata">=</stringProp>
+                                      </elementProp>
+                                    EOF
+              }
+          end
+      }
+    end
+  end
+
+  class OsProcessSampler
+    prepend OsProcessSamplerBuildArgs
+  end
+end

--- a/spec/os_process_sampler_spec.rb
+++ b/spec/os_process_sampler_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe 'os_process_sampler' do
+  let(:sampler_fragment) { doc.search('//SystemSampler').first }
+  let(:arguments_fragment) { sampler_fragment.search(".//elementProp[@name='SystemSampler.arguments']") }
+  let(:collection_fragment) { arguments_fragment.search(".//collectionProp['Argument.arguments']") }
+
+  context 'when no command args are provided' do
+    let(:doc) do
+      test do
+        threads count: 1 do
+          os_process_sampler command: 'my_command'
+        end
+      end.to_doc
+    end
+
+    it 'there are no arguments' do
+      expect(arguments_fragment.text).to eq ''
+    end
+  end
+
+  context 'command args are provided' do
+    let(:doc) do
+      test do
+        threads count: 1 do
+          os_process_sampler command: 'my_command', command_args: ['arg1', 'arg2']
+        end
+      end.to_doc
+    end
+
+    let(:elemprop_fragments) { collection_fragment.search(".//elementProp[@elementType='Argument']") }
+
+    it 'the arguments are passed through' do
+      expect(elemprop_fragments.count).to eq 2
+    end
+
+    it 'contains an entry for each argument' do
+      expect(elemprop_fragments.first.search(".//stringProp[@name='Argument.value']").first.text).to eq('arg1')
+      expect(elemprop_fragments.last.search(".//stringProp[@name='Argument.value']").first.text).to eq('arg2')
+    end
+  end
+end


### PR DESCRIPTION
To simplify providing arguments for commands when using the os process
sampler, extending the DSL with an option to provide 'command_args' as a
parameter with an array of arguments to be used