### PR TITLE
Add a force delete option to replace old result

### DIFF
--- a/lib/ruby-jmeter/dsl.rb
+++ b/lib/ruby-jmeter/dsl.rb
@@ -38,7 +38,7 @@ module RubyJmeter
       file(params)
       logger.warn 'Test executing locally ...'
 
-      cmd = "#{params[:path] ? File.join(params[:path], 'jmeter') : 'jmeter'} #{"-n" unless params[:gui] } -t #{params[:file]} -j #{params[:log] ? params[:log] : 'jmeter.log' } -l #{params[:jtl] ? params[:jtl] : 'jmeter.jtl' } #{build_properties(params[:properties]) if params[:properties]}"
+      cmd = "#{params[:path] ? File.join(params[:path], 'jmeter') : 'jmeter'} #{"-n" unless params[:gui] } -t #{params[:file]} -j #{params[:log] ? params[:log] : 'jmeter.log' } #{"-f" if params[:force_delete]} -l #{params[:jtl] ? params[:jtl] : 'jmeter.jtl' } #{build_properties(params[:properties]) if params[:properties]}"
       logger.debug cmd if params[:debug]
       Open3.popen2e("#{cmd}") do |stdin, stdout_err, wait_thr|
         while line = stdout_err.gets


### PR DESCRIPTION
I think it's a very common option for developers to delete existing results files before start the test. Therefore, I added a little tweak to support it.