### PR TITLE
add support of webdriver config (chrome driver) and sampler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ tmp
 *.bak
 .byebug_history
 .DS_Store
+*.swp

--- a/lib/ruby-jmeter/extend/plugins/jmeter_plugins.rb
+++ b/lib/ruby-jmeter/extend/plugins/jmeter_plugins.rb
@@ -116,5 +116,15 @@ module RubyJmeter
       node = RubyJmeter::Plugins::JMXCollector.new(params)
       attach_node(node, &block)
     end
+
+    def webdriver_chromedriver(params = {}, &block)
+      node = RubyJmeter::Plugins::WebDriverChromeDriver.new(params)
+      attach_node(node, &block)
+    end
+
+    def webdriver_sampler(params = {}, &block)
+      node = RubyJmeter::Plugins::WebDriverSampler.new(params)
+      attach_node(node, &block)
+    end
   end
 end

--- a/lib/ruby-jmeter/plugins/webdriver_chromedriver.rb
+++ b/lib/ruby-jmeter/plugins/webdriver_chromedriver.rb
@@ -1,0 +1,36 @@
+module RubyJmeter
+  module Plugins
+    class WebDriverChromeDriver
+      attr_accessor :doc
+      include Helper
+      def initialize(params={})
+        testname = params.kind_of?(Array) ? 'jp@gc - Chrome Driver Config' : (params[:name] || 'jp@gc - Chrome Driver Config')
+        @doc = Nokogiri::XML(<<-XML.strip_heredoc)
+          <com.googlecode.jmeter.plugins.webdriver.config.ChromeDriverConfig guiclass="com.googlecode.jmeter.plugins.webdriver.config.gui.ChromeDriverConfigGui" testclass="com.googlecode.jmeter.plugins.webdriver.config.ChromeDriverConfig" testname="#{testname}" enabled="true">
+          <stringProp name="WebDriverConfig.proxy_type">SYSTEM</stringProp>
+          <stringProp name="WebDriverConfig.proxy_pac_url"></stringProp>
+          <stringProp name="WebDriverConfig.http_host"></stringProp>
+          <intProp name="WebDriverConfig.http_port">8080</intProp>
+          <boolProp name="WebDriverConfig.use_http_for_all_protocols">true</boolProp>
+          <stringProp name="WebDriverConfig.https_host"></stringProp>
+          <intProp name="WebDriverConfig.https_port">8080</intProp>
+          <stringProp name="WebDriverConfig.ftp_host"></stringProp>
+          <intProp name="WebDriverConfig.ftp_port">8080</intProp>
+          <stringProp name="WebDriverConfig.socks_host"></stringProp>
+          <intProp name="WebDriverConfig.socks_port">8080</intProp>
+          <stringProp name="WebDriverConfig.no_proxy">localhost</stringProp>
+          <boolProp name="WebDriverConfig.maximize_browser">true</boolProp>
+          <boolProp name="WebDriverConfig.reset_per_iteration">false</boolProp>
+          <boolProp name="WebDriverConfig.dev_mode">false</boolProp>
+          <stringProp name="ChromeDriverConfig.chromedriver_path"></stringProp>
+          <boolProp name="ChromeDriverConfig.android_enabled">false</boolProp>
+          <boolProp name="ChromeDriverConfig.headless_enabled">false</boolProp>
+          <boolProp name="ChromeDriverConfig.insecurecerts_enabled">false</boolProp>
+        </com.googlecode.jmeter.plugins.webdriver.config.ChromeDriverConfig>
+        XML
+        update params
+        update_at_xpath params if params.is_a?(Hash) && params[:update_at_xpath]
+      end
+    end
+  end
+end

--- a/lib/ruby-jmeter/plugins/webdriver_sampler.rb
+++ b/lib/ruby-jmeter/plugins/webdriver_sampler.rb
@@ -1,0 +1,20 @@
+module RubyJmeter
+  module Plugins
+    class WebDriverSampler
+      attr_accessor :doc
+      include Helper
+      def initialize(params={})
+        testname = params.kind_of?(Array) ? 'jp@gc - WebDriver Sampler' : (params[:name] || 'jp@gc - WebDriver Sampler')
+        @doc = Nokogiri::XML(<<-XML.strip_heredoc)
+          <com.googlecode.jmeter.plugins.webdriver.sampler.WebDriverSampler guiclass="com.googlecode.jmeter.plugins.webdriver.sampler.gui.WebDriverSamplerGui" testclass="com.googlecode.jmeter.plugins.webdriver.sampler.WebDriverSampler" testname="#{testname}" enabled="true">
+          <stringProp name="WebDriverSampler.script"></stringProp>
+          <stringProp name="WebDriverSampler.parameters"></stringProp>
+          <stringProp name="WebDriverSampler.language">javascript</stringProp>
+        </com.googlecode.jmeter.plugins.webdriver.sampler.WebDriverSampler>
+        XML
+        update params
+        update_at_xpath params if params.is_a?(Hash) && params[:update_at_xpath]
+      end
+    end
+  end
+end

--- a/spec/jmeter_plugins_spec.rb
+++ b/spec/jmeter_plugins_spec.rb
@@ -243,3 +243,58 @@ describe 'jmx collector' do
 
 end
 
+describe 'webdriver chromedriver config' do
+  let(:doc) do
+    test do
+      threads do
+        webdriver_chromedriver name: 'webdriver test name',
+          http_port: 5678,
+          chromedriver_path: "/home/usr/test/chrome"
+
+      end
+    end.to_doc
+  end
+
+  let(:fragment) { doc.search("//com.googlecode.jmeter.plugins.webdriver.config.ChromeDriverConfig").first }
+
+  it 'should have a name' do
+    expect(fragment.attributes['testname'].value).to eq 'webdriver test name'
+  end
+
+  it 'should have a port' do
+    expect(fragment.search("//intProp[@name='WebDriverConfig.http_port']").text).to eq '5678'
+  end
+
+  it 'should configure a path' do
+    expect(fragment.search("//stringProp[@name='ChromeDriverConfig.chromedriver_path']").text).to eq '/home/usr/test/chrome'
+  end
+
+end
+
+describe 'webdriver sampler' do
+  let(:doc) do
+    test do
+      threads do
+        webdriver_sampler name: 'webdriver sampler',
+          language: "c",
+          script: 'WDS.test'
+
+      end
+    end.to_doc
+  end
+
+  let(:fragment) { doc.search("//com.googlecode.jmeter.plugins.webdriver.sampler.WebDriverSampler").first }
+
+  it 'should have a name' do
+    expect(fragment.attributes['testname'].value).to eq 'webdriver sampler'
+  end
+
+  it 'should configure a language' do
+    expect(fragment.search("//stringProp[@name='WebDriverSampler.language']").text).to eq 'c'
+  end
+
+  it 'should configure a script' do
+    expect(fragment.search("//stringProp[@name='WebDriverSampler.script']").text).to eq 'WDS.test'
+  end
+
+end


### PR DESCRIPTION
This is also for https://github.com/flood-io/ruby-jmeter/issues/81