### PR TITLE
Change Fixnum to Integer

### DIFF
--- a/lib/ruby-jmeter/extend/threads/setup_thread_group.rb
+++ b/lib/ruby-jmeter/extend/threads/setup_thread_group.rb
@@ -2,7 +2,7 @@ module RubyJmeter
   class ExtendedDSL < DSL
     def setup_thread_group(*args, &block)
       params = args.shift || {}
-      params = { count: params }.merge(args.shift || {}) if params.class == Fixnum
+      params = { count: params }.merge(args.shift || {}) if params.class == Integer
       params[:num_threads] = params[:count] || 1
       params[:ramp_time] = params[:rampup] || (params[:num_threads]/2.0).ceil
       params[:start_time] = params[:start_time] || Time.now.to_i * 1000

--- a/lib/ruby-jmeter/extend/threads/thread_group.rb
+++ b/lib/ruby-jmeter/extend/threads/thread_group.rb
@@ -2,7 +2,7 @@ module RubyJmeter
   class ExtendedDSL < DSL
     def thread_group(*args, &block)
       params = args.shift || {}
-      params = { count: params }.merge(args.shift || {}) if params.class == Fixnum
+      params = { count: params }.merge(args.shift || {}) if params.class == Integer
       params[:num_threads] = params[:count] || 1
       params[:ramp_time] = params[:rampup] || (params[:num_threads]/2.0).ceil
       params[:start_time] = params[:start_time] || Time.now.to_i * 1000


### PR DESCRIPTION
From ruby 2.4 Fixnum is deprecated in favor of Integer so that I changed all Fixnum to Integer.


Fix: https://github.com/flood-io/ruby-jmeter/issues/147