### PR TITLE
Allow extract params from response headers

### DIFF
--- a/lib/ruby-jmeter/dsl/regular_expression_extractor.rb
+++ b/lib/ruby-jmeter/dsl/regular_expression_extractor.rb
@@ -12,9 +12,10 @@ module RubyJmeter
 
     def initialize(params={})
       testname = params.kind_of?(Array) ? 'RegularExpressionExtractor' : (params[:name] || 'RegularExpressionExtractor')
+      use_headers = params.fetch(:use_headers, false)
       @doc = Nokogiri::XML(<<-EOS.strip_heredoc)
 <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="#{testname}" enabled="true">
-  <stringProp name="RegexExtractor.useHeaders">false</stringProp>
+  <stringProp name="RegexExtractor.useHeaders">#{use_headers}</stringProp>
   <stringProp name="RegexExtractor.refname"/>
   <stringProp name="RegexExtractor.regex"/>
   <stringProp name="RegexExtractor.template"/>

--- a/spec/regular_expression_extractor_spec.rb
+++ b/spec/regular_expression_extractor_spec.rb
@@ -4,11 +4,15 @@ describe 'regular_expression_extractor' do
   describe 'standard scope' do
     let(:doc) do
       test do
-        regex pattern: 'pattern', name: 'my_variable', match_number: 1, default: '424242'
+        regex pattern: 'pattern', name: 'my_variable', match_number: 1, default: '424242', use_headers: true
       end.to_doc
     end
 
     let(:fragment) { doc.search('//RegexExtractor').first }
+
+    it 'matches on scope' do
+      expect(fragment.search(".//stringProp[@name='RegexExtractor.useHeaders']").text).to eq 'true'
+    end
 
     it 'matches on refname' do
       expect(fragment.search(".//stringProp[@name='RegexExtractor.refname']").text).to eq 'my_variable'


### PR DESCRIPTION
In order to be able to extract params from the response headers using the regex extractor, this is especially useful for SPA (Single Page Applications) because some of them use token-based authentication strategy where the server answer you a token un the response headers, so in the next request the client makes have that token and the server knows it came from the same client