### PR TITLE
Use is_a? method instead of compare class names

### DIFF
--- a/lib/ruby-jmeter/extend/controllers/transaction_controller.rb
+++ b/lib/ruby-jmeter/extend/controllers/transaction_controller.rb
@@ -2,7 +2,7 @@ module RubyJmeter
   class ExtendedDSL < DSL
     def transaction_controller(*args, &block)
       params = args.shift || {}
-      params = { name: params }.merge(args.shift || {}) if params.class == String
+      params = { name: params }.merge(args.shift || {}) if params.is_a?(String)
       params[:parent] = params[:parent] || false
       params[:includeTimers] = params[:include_timers] || false
       node = RubyJmeter::TransactionController.new(params)

--- a/lib/ruby-jmeter/extend/samplers/http_request.rb
+++ b/lib/ruby-jmeter/extend/samplers/http_request.rb
@@ -2,7 +2,7 @@ module RubyJmeter
   class ExtendedDSL < DSL
     def http_request(*args, &block)
       params = args.shift || {}
-      params = { url: params }.merge(args.shift || {}) if params.class == String
+      params = { url: params }.merge(args.shift || {}) if params.is_a?(String)
 
       params[:method] ||= case __callee__.to_s
       when 'visit'

--- a/lib/ruby-jmeter/extend/threads/setup_thread_group.rb
+++ b/lib/ruby-jmeter/extend/threads/setup_thread_group.rb
@@ -2,7 +2,7 @@ module RubyJmeter
   class ExtendedDSL < DSL
     def setup_thread_group(*args, &block)
       params = args.shift || {}
-      params = { count: params }.merge(args.shift || {}) if params.class == Fixnum
+      params = { count: params }.merge(args.shift || {}) if params.is_a?(Integer)
       params[:num_threads] = params[:count] || 1
       params[:ramp_time] = params[:rampup] || (params[:num_threads]/2.0).ceil
       params[:start_time] = params[:start_time] || Time.now.to_i * 1000

--- a/lib/ruby-jmeter/extend/threads/thread_group.rb
+++ b/lib/ruby-jmeter/extend/threads/thread_group.rb
@@ -2,7 +2,7 @@ module RubyJmeter
   class ExtendedDSL < DSL
     def thread_group(*args, &block)
       params = args.shift || {}
-      params = { count: params }.merge(args.shift || {}) if params.class == Fixnum
+      params = { count: params }.merge(args.shift || {}) if params.is_a?(Integer)
       params[:num_threads] = params[:count] || 1
       params[:ramp_time] = params[:rampup] || (params[:num_threads]/2.0).ceil
       params[:start_time] = params[:start_time] || Time.now.to_i * 1000

--- a/lib/ruby-jmeter/helpers/helper.rb
+++ b/lib/ruby-jmeter/helpers/helper.rb
@@ -17,12 +17,12 @@ module RubyJmeter
     def update(params)
       params.delete(:name)
       enabled_disabled(params)
-      if params.class == Array
+      if params.is_a?(Array)
         update_collection params
       else
         params.each do |name, value|
           node = @doc.children.xpath("//*[contains(@name,\"#{name.to_s}\")]")
-          if value.class == Nokogiri::XML::Builder
+          if value.is_a?(Nokogiri::XML::Builder)
             node.first.children = value.doc.at_xpath('//builder').children
           else
             node.first.content = value unless node.empty?


### PR DESCRIPTION
Close #147

Use the is_a? method instead of comparing the class names directly so we keep code in a rubist manner